### PR TITLE
feat(CAS-108): pin all GitHub Actions to full SHAs and enforce policy

### DIFF
--- a/.cascadeguard/actions-policy.yaml
+++ b/.cascadeguard/actions-policy.yaml
@@ -1,0 +1,29 @@
+# CascadeGuard Actions Policy
+# Schema: https://cascadeguard.dev/schemas/actions-policy/v1
+#
+# All external GitHub Actions used in this repository must appear in
+# allowed_actions or be published by a trusted owner in allowed_owners.
+
+version: "1"
+
+# Reject any action not explicitly permitted below.
+default: deny
+
+# GitHub organisations whose actions are trusted by default.
+allowed_owners:
+  - actions       # github.com/actions/*
+  - docker        # github.com/docker/*
+
+# Specific actions permitted by name (owner/repo).
+allowed_actions:
+  - sigstore/cosign-installer
+  - anchore/scan-action
+  - anchore/sbom-action
+  - aquasecurity/trivy-action
+  - github/codeql-action/upload-sarif
+
+# Actions that are always denied, even if the owner is trusted.
+denied_actions: []
+
+# One-off exceptions — each must include a 'reason'.
+exceptions: []

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -53,14 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build${{ inputs.push && ' and push' || '' }} image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -80,7 +80,7 @@ jobs:
           cache-to: ${{ inputs.push && format('type=gha,scope={0},mode=max', inputs.name) || '' }}
 
       - name: Scan with Grype
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6
         with:
           # On PRs (load=true), use the local image ID to avoid registry pull attempts
           image: ${{ inputs.push && format('{0}/{1}:{2}', inputs.registry, inputs.image, inputs.tag) || steps.build.outputs.imageid }}
@@ -89,7 +89,7 @@ jobs:
           output-format: table
 
       - name: Scan with Trivy
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           # On PRs (load=true), use the local image ID to avoid registry pull attempts
           image-ref: ${{ inputs.push && format('{0}/{1}:{2}', inputs.registry, inputs.image, inputs.tag) || steps.build.outputs.imageid }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Generate SBOM (Syft)
         if: inputs.push
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.tag }}
           format: spdx-json
@@ -108,7 +108,7 @@ jobs:
 
       - name: Sign image with Cosign
         if: inputs.push && inputs.sign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
       - name: Run Cosign keyless sign
         if: inputs.push && inputs.sign
         env:

--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -37,7 +37,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install CascadeGuard
-        run: pip install --quiet cascadeguard
+        # Install from CAS-105 branch until the actions audit subcommand is
+        # published to PyPI. Switch to `pip install cascadeguard` once released.
+        run: |
+          pip install --quiet \
+            "git+https://github.com/cascadeguard/cascadeguard.git@CAS-105/actions-policy-schema-and-audit#subdirectory=app"
 
       - name: Audit GitHub Actions policy
         run: |

--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -1,0 +1,46 @@
+# CascadeGuard — Actions Policy Enforcement
+#
+# Validates all workflow files against .cascadeguard/actions-policy.yaml
+# using the `cascadeguard actions audit` CLI.
+#
+# Runs on every pull request to main to prevent unpinned or disallowed
+# actions from being merged.
+
+name: Enforce Actions Policy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".cascadeguard/actions-policy.yaml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".cascadeguard/actions-policy.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit Actions Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CascadeGuard
+        run: pip install --quiet cascadeguard
+
+      - name: Audit GitHub Actions policy
+        run: |
+          cascadeguard actions audit \
+            --policy .cascadeguard/actions-policy.yaml \
+            --workflows-dir .github/workflows

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # full history for changelog
 
@@ -72,7 +72,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           CHANGES: ${{ steps.changelog.outputs.CHANGES }}
           IMAGES: ${{ steps.image-list.outputs.IMAGES }}

--- a/.github/workflows/scheduled-scan.yaml
+++ b/.github/workflows/scheduled-scan.yaml
@@ -28,14 +28,14 @@ jobs:
               tag: "latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Pull published image
         run: docker pull ${{ matrix.registry }}/${{ matrix.image }}:${{ matrix.tag }}
 
       - name: Scan with Grype
         id: grype
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6
         with:
           image: ${{ matrix.registry }}/${{ matrix.image }}:${{ matrix.tag }}
           fail-build: false
@@ -44,7 +44,7 @@ jobs:
           output-file: grype-${{ matrix.name }}.json
 
       - name: Scan with Trivy (SARIF)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ matrix.registry }}/${{ matrix.image }}:${{ matrix.tag }}
           format: sarif
@@ -53,7 +53,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         if: always()
         with:
           sarif_file: trivy-${{ matrix.name }}.sarif
@@ -61,7 +61,7 @@ jobs:
 
       - name: Open CVE issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = `[CVE] New vulnerabilities in ${{ matrix.name }}`;


### PR DESCRIPTION
## Summary

Dogfoods the [CAS-108](/CAS/issues/CAS-108) acceptance criteria for cascadeguard-exemplar.

- Pin all 14 mutable action refs to full commit SHAs across build-image.yaml, release.yaml, and scheduled-scan.yaml
- Manually pin `github/codeql-action/upload-sarif@v3` to SHA (path action not auto-resolved)
- Add `.cascadeguard/actions-policy.yaml` — deny-by-default policy
- Add `.github/workflows/enforce-actions-policy.yaml` CI check

## Test plan

- [ ] All `uses:` refs are SHA-pinned (no @tag or @branch refs remain)
- [ ] `actions-policy.yaml` covers all external actions used
- [ ] Policy enforcement workflow triggers on workflow/policy changes

Paperclip issue: [CAS-108](/CAS/issues/CAS-108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>