### PR TITLE
feat(CAS-264): register exemplar-web-cloudflare in exemplar images catalog

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -8,3 +8,14 @@
     branch: main
   rebuildDelay: 7d
   autoRebuild: true
+
+- name: exemplar-web-cloudflare
+  registry: ghcr.io
+  repository: cascadeguard/exemplar-web-cloudflare
+  source:
+    provider: github
+    repo: cascadeguard/cascadeguard-exemplar-web-cloudflare
+    dockerfile: Dockerfile
+    branch: main
+  rebuildDelay: 7d
+  autoRebuild: true


### PR DESCRIPTION
## Summary

- Adds `exemplar-web-cloudflare` entry to `images.yaml` catalog
- Image: `ghcr.io/cascadeguard/exemplar-web-cloudflare`
- Source: `cascadeguard/cascadeguard-exemplar-web-cloudflare` (Dockerfile at repo root, branch main)
- `autoRebuild: true` and `rebuildDelay: 7d` matching hello-world convention

Depends on [CAS-263](https://paperclip.lab.ctoaas.co/CAS/issues/CAS-263) (exemplar repo setup, now in_review).

Paperclip issue: [CAS-264](https://paperclip.lab.ctoaas.co/CAS/issues/CAS-264)

## Test plan

- [ ] Verify `images.yaml` YAML is valid and follows existing schema conventions
- [ ] Confirm image name / repository match what was enrolled in the source repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)