### PR TITLE
docs(CAS-497): add openjdk deprecated image exemplar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # cascadeguard-exemplar
 
-Example CascadeGuard state repo with a hello-world nginx image. Demonstrates
-every task-mode CLI command against a real directory layout.
+Example CascadeGuard state repo. Demonstrates task-mode CLI commands and
+deprecation detection against real directory layouts.
+
+## Examples
+
+| Example | Base image | Purpose |
+|---|---|---|
+| [`local/hello-world`](local/hello-world/) | `nginx` | Basic enrolled image — full task-mode CLI walkthrough |
+| [`local/deprecated-openjdk`](local/deprecated-openjdk/) | `openjdk:17-alpine` | Deprecated base image — shows `DEPRECATED` finding + `eclipse-temurin` recommendation |
 
 ## Repository layout
 
 ```
 .
 ├── local/
-│   └── hello-world/
-│       ├── Dockerfile               # hello-world nginx image
-│       └── index.html               # static page served by nginx
+│   ├── hello-world/
+│   │   ├── Dockerfile               # hello-world nginx image
+│   │   └── index.html               # static page served by nginx
+│   └── deprecated-openjdk/
+│       ├── Dockerfile               # openjdk:17-alpine (deprecated — exemplar only)
+│       └── README.md                # deprecation detection walkthrough
 ├── images.yaml                      # enrollment configuration
 ├── .cascadeguard.yaml               # CascadeGuard config (ci.platform, etc.)
 ├── .github/workflows/               # auto-generated CI pipelines (generate-ci)
@@ -145,3 +155,37 @@ remove an image.
 
 The pre-generated files in this repo were produced by running this command
 against the hello-world entry in `images.yaml`.
+
+## Deprecated image detection
+
+CascadeGuard detects base images that have been officially deprecated on
+Docker Hub and recommends actively maintained replacements.
+
+### Example: openjdk → eclipse-temurin
+
+`openjdk` was deprecated in November 2022 and no longer receives security
+patches. The `local/deprecated-openjdk/Dockerfile` uses `openjdk:17-alpine`
+to demonstrate the detection flow:
+
+```bash
+cascadeguard scan local/deprecated-openjdk/Dockerfile
+```
+
+Expected output:
+
+```
+DEPRECATED  openjdk:17-alpine
+  The 'openjdk' image is deprecated and no longer receives security updates.
+  Recommended replacement: eclipse-temurin:17-alpine
+  See: https://hub.docker.com/_/openjdk
+```
+
+Fix the Dockerfile by replacing the deprecated base image:
+
+```diff
+-FROM openjdk:17-alpine
++FROM eclipse-temurin:17-alpine
+```
+
+See [`local/deprecated-openjdk/README.md`](local/deprecated-openjdk/README.md)
+for the full walkthrough.

--- a/local/deprecated-openjdk/Dockerfile
+++ b/local/deprecated-openjdk/Dockerfile
@@ -1,0 +1,23 @@
+# Example: deprecated base image (openjdk is end-of-life)
+#
+# openjdk was deprecated on Docker Hub in November 2022. The official
+# successor is eclipse-temurin. Running CascadeGuard scan against this
+# Dockerfile produces a DEPRECATED finding:
+#
+#   DEPRECATED  openjdk:17-alpine
+#     The 'openjdk' image is deprecated and no longer receives security updates.
+#     Recommended replacement: eclipse-temurin:17-alpine
+#
+# See: https://hub.docker.com/_/openjdk (deprecation notice)
+#      https://hub.docker.com/_/eclipse-temurin (recommended replacement)
+
+FROM openjdk:17-alpine
+
+WORKDIR /app
+
+# Simple "hello world" jar would go here in a real service.
+# This file intentionally left minimal — it is a deprecation-detection exemplar,
+# not a production image.
+COPY README.md /app/
+
+CMD ["java", "-version"]

--- a/local/deprecated-openjdk/README.md
+++ b/local/deprecated-openjdk/README.md
@@ -1,0 +1,46 @@
+# deprecated-openjdk — Deprecated Base Image Exemplar
+
+This example demonstrates CascadeGuard's deprecated base image detection.
+
+## What this shows
+
+`openjdk` was officially deprecated on Docker Hub in November 2022. The image
+no longer receives security updates. The maintained successor is
+[`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin).
+
+When CascadeGuard scans this Dockerfile it reports a `DEPRECATED` finding:
+
+```
+DEPRECATED  openjdk:17-alpine
+  The 'openjdk' image is deprecated and no longer receives security updates.
+  Recommended replacement: eclipse-temurin:17-alpine
+  See: https://hub.docker.com/_/openjdk
+```
+
+## Running the scan
+
+From the root of this repository:
+
+```bash
+cascadeguard scan local/deprecated-openjdk/Dockerfile
+```
+
+Expected output includes a `DEPRECATED` finding with the recommended
+`eclipse-temurin` replacement and a link to the Docker Hub deprecation notice.
+
+## Fixing the finding
+
+Replace the `FROM` line in the Dockerfile:
+
+```diff
+-FROM openjdk:17-alpine
++FROM eclipse-temurin:17-alpine
+```
+
+Re-run the scan to confirm the finding is resolved.
+
+## Why eclipse-temurin?
+
+`eclipse-temurin` is the Eclipse Adoptium distribution of OpenJDK — the
+official, actively maintained successor to `openjdk` on Docker Hub. It
+receives regular security updates and follows the same versioning scheme.


### PR DESCRIPTION
## Summary

Adds `local/deprecated-openjdk/` as a reference example demonstrating CascadeGuard deprecated base image detection.

- **`local/deprecated-openjdk/Dockerfile`** — uses `openjdk:17-alpine` (EOL November 2022) as a canonical deprecated-base-image example
- **`local/deprecated-openjdk/README.md`** — walkthrough: expected `DEPRECATED` finding, `eclipse-temurin:17-alpine` replacement, and fix-and-re-scan steps
- **`README.md`** — new Examples table + "Deprecated image detection" section with scan command and expected output

## Context

- [CAS-497](/CAS/issues/CAS-497) — exemplar update for deprecated image strategy
- Depends on CAS-494 (data model) + CAS-496 (CLI detection) for the detection to actually fire; this PR adds the exemplar/docs layer now so the full flow is documented
- `openjdk` was deprecated on Docker Hub in Nov 2022; `eclipse-temurin` is the official successor

## Test plan

- [ ] PR CI passes
- [ ] `local/deprecated-openjdk/Dockerfile` is valid Docker syntax (`docker build --no-cache` or linter)
- [ ] README renders correctly on GitHub
- [ ] Once CAS-496 lands: `cascadeguard scan local/deprecated-openjdk/Dockerfile` produces a `DEPRECATED` finding pointing to `eclipse-temurin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)