### PR TITLE
chore: bump CLI to a028744 (CAS-564 multi-registry tag fetching)

### DIFF
--- a/.cascadeguard.yaml
+++ b/.cascadeguard.yaml
@@ -5,5 +5,9 @@
 image: ghcr.io/cascadeguard/cascadeguard
 version: v1.0.0
 
+cli:
+  # Pin to feat(CAS-564): multi-registry OCI tag fetching for ghcr.io and quay.io.
+  version: "a028744c4cf1733c5c1d5df725260f285eb1698c"
+
 ci:
   platform: github  # target CI platform for `task generate-ci`

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       image_path: ${{ inputs.image_path }}
       image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Generate build matrix
         id: gen
-        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@510b0009b78df3114345cb907db6b026da79d7ab # main
         with:
           image-filter: ${{ github.event.inputs.image_filter || '' }}
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
       - run: cascadeguard images validate
 
   # ── Per-Image Build ──────────────────────────────────────────────
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       image_path: ${{ matrix.image_path }}
       image_name: ${{ matrix.image_name }}
@@ -71,7 +71,7 @@ jobs:
 
   # ── Actions Policy ───────────────────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
 
   # ── Build Gate ───────────────────────────────────────────────────
   build-gate:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,5 +21,5 @@ permissions:
 
 jobs:
   check:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     secrets: inherit

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up CascadeGuard CLI
-        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
       - name: CascadeGuard validate
         run: cascadeguard images validate
 
   # ── Actions Policy Enforcement ───────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@1c3e7fdffa70db9a3d0f6af78545b137d7a0f8b4 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main


### PR DESCRIPTION
## Summary

Bump CascadeGuard CLI to post-CAS-564 merge SHA `a028744c` which added:
- Multi-registry OCI tag fetching (ghcr.io, quay.io)
- `skip_tag_fetch` for unsupported registries

Changes:
- Add `cli.version: a028744c` to `.cascadeguard.yaml`
- Pin `enforce-actions-policy.yaml` install from `@main` to SHA

Refs: CAS-578, CAS-564

## Test plan
- [ ] CI passes on this PR