### PR TITLE
fix(ci): grant pull-requests: write to check workflow caller

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   packages: read
   issues: write
+  pull-requests: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `pull-requests: write` to the `permissions` block in `check.yaml`
- The shared `check.yaml` in `cascadeguard-actions` requests this permission for state-file PR commits; cross-repo callers must explicitly grant it or GitHub applies `pull-requests: none`
- `cascadeguard-data` and `cascadeguard-open-secure-images` already have this permission — this aligns `cascadeguard-exemplar` with them

## Root cause

When a reusable workflow is called from an external repo, the effective permissions are the intersection of caller-granted and callee-requested permissions. The caller must explicitly list `pull-requests: write` for the callee to use it.

## Test plan

- [ ] Trigger `workflow_dispatch` on Check workflow after merge — expect no permission validation error

## Paperclip issue

[CAS-578](/CAS/issues/CAS-578)

🤖 Generated with [Claude Code](https://claude.com/claude-code)